### PR TITLE
Add a public reset method

### DIFF
--- a/vendor/assets/javascripts/soundmanager2-nodebug.js
+++ b/vendor/assets/javascripts/soundmanager2-nodebug.js
@@ -521,7 +521,7 @@ function SoundManager(smURL, smID) {
   this._wD = this._writeDebug;
   this._debug = function() {
   };
-  this.reboot = function() {
+  this.reset = function(bClear) {
     var i, j;
     for (i = _s.soundIDs.length-1; i >= 0; i--) {
       _s.sounds[_s.soundIDs[i]].destruct();
@@ -540,13 +540,20 @@ function SoundManager(smURL, smID) {
     _s.soundIDs = [];
     _s.sounds = {};
     _flash = null;
-    for (i in _on_queue) {
-      if (_on_queue.hasOwnProperty(i)) {
-        for (j = _on_queue[i].length-1; j >= 0; j--) {
-          _on_queue[i][j].fired = false;
+    if (bClear) {
+      _on_queue = [];
+    } else {
+      for (i in _on_queue) {
+        if (_on_queue.hasOwnProperty(i)) {
+          for (j = _on_queue[i].length-1; j >= 0; j--) {
+            _on_queue[i][j].fired = false;
+          }
         }
       }
     }
+  };
+  this.reboot = function() {
+    _s.reset();
     _win.setTimeout(_s.beginDelayedInit, 20);
   };
   this.getMoviePercent = function() {

--- a/vendor/assets/javascripts/soundmanager2.js
+++ b/vendor/assets/javascripts/soundmanager2.js
@@ -1231,13 +1231,14 @@ function SoundManager(smURL, smID) {
   };
 
   /**
-   * Restarts and re-initializes the SoundManager instance.
+   * Reset state of SoundManager instance.
+   *
+   * @param {boolean} bClear Optional: Whether to clear event callbacks
    */
 
-  this.reboot = function() {
+  this.reset = function(bClear) {
 
-    // attempt to reset and init SM2
-    _s._wD(_sm+'.reboot()');
+    _s._wD(_sm+'.reset()');
 
     // <d>
     if (_s.soundIDs.length) {
@@ -1274,13 +1275,34 @@ function SoundManager(smURL, smID) {
     _s.sounds = {};
     _flash = null;
 
-    for (i in _on_queue) {
-      if (_on_queue.hasOwnProperty(i)) {
-        for (j = _on_queue[i].length-1; j >= 0; j--) {
-          _on_queue[i][j].fired = false;
+    if (bClear) {
+
+      _on_queue = [];
+
+    } else {
+
+      // reset fired state on event callbacks
+      for (i in _on_queue) {
+        if (_on_queue.hasOwnProperty(i)) {
+          for (j = _on_queue[i].length-1; j >= 0; j--) {
+            _on_queue[i][j].fired = false;
+          }
         }
       }
     }
+
+  };
+
+  /**
+   * Restarts and re-initializes the SoundManager instance.
+   */
+
+  this.reboot = function() {
+
+    // attempt to reset and init SM2
+    _s._wD(_sm+'.reboot()');
+
+    _s.reset();
 
     _s._wD(_sm + ': Rebooting...');
     _win.setTimeout(_s.beginDelayedInit, 20);


### PR DESCRIPTION
This works like a reboot, except that it doesn't finish with a re-initialization. There is also an option to clear the bound event callbacks rather than resetting their fired state.

This is necessary when doing page loads/replacement via ajax, as the SoundManager's state becomes stale.
