### PR TITLE
swapping slashes in gemspec file list regex to remove bundler warning

### DIFF
--- a/soundmanager-rails.gemspec
+++ b/soundmanager-rails.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/glaszig/soundmanager-rails"
   gem.version       = Soundmanager::Rails::VERSION
 
-  gem.files         = `git ls-files`.split($\)
+  gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "soundmanager-rails"


### PR DESCRIPTION
A typo in the gemspec was splitting `git ls-files` at all spaces, rather than new-lines only. This caused Bundler to warn of bad files:

```
soundmanager-rails at ... did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["test/dummy/public/low", "flight", "v2.mp3"] are not files
```

Swapping the line for the common ``git ls-files`.split($/)` fixes the problem.
